### PR TITLE
Add flipped bind operator `(=<<)` and missing `ap` export

### DIFF
--- a/src/Prelude.curry
+++ b/src/Prelude.curry
@@ -28,7 +28,7 @@ module Prelude
   -- Type Constructor Classes
   , Functor (..), Applicative (..), Alternative (..)
   , Monad (..), MonadFail(..)
-  , (=<<), liftM2, sequence, sequence_, mapM, mapM_
+  , (=<<), ap, liftM2, sequence, sequence_, mapM, mapM_
 
   -- * Operations on Characters
   , isUpper, isLower, isAlpha, isDigit, isAlphaNum

--- a/src/Prelude.curry
+++ b/src/Prelude.curry
@@ -28,7 +28,7 @@ module Prelude
   -- Type Constructor Classes
   , Functor (..), Applicative (..), Alternative (..)
   , Monad (..), MonadFail(..)
-  , liftM2, sequence, sequence_, mapM, mapM_
+  , (=<<), liftM2, sequence, sequence_, mapM, mapM_
 
   -- * Operations on Characters
   , isUpper, isLower, isAlpha, isDigit, isAlphaNum
@@ -83,6 +83,7 @@ infixl 3 <|>
 infixr 3 &&
 infixr 2 ||
 infixl 1 >>, >>=
+infixr 1 =<<
 infixr 0 ?, $, $!, $!!, $#, $##, `seq`, &, &>
 
 --- The externally defined type of characters.
@@ -1611,6 +1612,9 @@ class Monad m => MonadFail m where
 
 instance MonadFail [] where
   fail _ = []
+
+(=<<) :: Monad m => (a -> m b) -> m a -> m b
+f =<< x = x >>= f
 
 ap :: Monad m => m (a -> b) -> m a -> m b
 ap m1 m2 = do


### PR DESCRIPTION
This operator is analogous to [the one defined in Haskell's Prelude](https://hackage.haskell.org/package/ghc-internal-9.1201.0/docs/src/GHC.Internal.Base.html#%3D%3C%3C), i.e. is `(>>=)` with its arguments flipped. This is occasionally useful because the parameters are ordered like "classic" prefix function application, similar to `fmap` or `(<$>)`.

Also, while we're at it, this adds a missing export for `ap`.