### PR TITLE
Implement `unsafeInterleaveIO`

### DIFF
--- a/src/System/IO/Unsafe.curry
+++ b/src/System/IO/Unsafe.curry
@@ -9,7 +9,7 @@
 {-# LANGUAGE CPP #-}
 
 module System.IO.Unsafe
-  ( unsafePerformIO, trace
+  ( unsafePerformIO, unsafeInterleaveIO, trace
   , spawnConstraint, isVar, identicalVar, isGround, compareAnyTerm
   , showAnyTerm, showAnyExpression
   , readsAnyUnqualifiedTerm, readAnyUnqualifiedTerm
@@ -21,6 +21,15 @@ import System.IO (hPutStrLn, stderr)
 --- Performs and hides an I/O action in a computation (use with care!).
 unsafePerformIO :: IO a -> a
 unsafePerformIO external
+
+--- Defers an I/O action to be executed lazily. In other words, the action
+--- will first be performed when the value is demanded.
+unsafeInterleaveIO :: IO a -> IO a
+#ifdef __KICS2__
+unsafeInterleaveIO external
+#else
+unsafeInterleaveIO x = return (unsafePerformIO x) -- Fallback implementation, relies on not being inlined
+#endif
 
 --- Prints the first argument as a side effect and behaves as identity on the
 --- second argument.

--- a/src/System/IO/Unsafe.kics2.hs
+++ b/src/System/IO/Unsafe.kics2.hs
@@ -9,9 +9,9 @@ external_d_C_unsafePerformIO io cd cs = unsafePerformIO (toIO errSupply cd cs io
 external_nd_C_unsafePerformIO :: Curry_Prelude.C_IO a -> IDSupply -> Cover -> ConstStore -> a
 external_nd_C_unsafePerformIO io s cd cs = unsafePerformIO (toIO s cd cs io)
 
-external_d_C_unsafeInterleaveIO :: Curry_Prelude.C_IO a -> Cover -> ConstStore -> a
+external_d_C_unsafeInterleaveIO :: Curry_Prelude.C_IO a -> Cover -> ConstStore -> Curry_Prelude.C_IO a
 external_d_C_unsafeInterleaveIO io cd cs = fromIO (unsafeInterleaveIO (toIO errSupply cd cs io))
   where errSupply = internalError "Unsafe.unsafeInterleaveIO: ID supply used"
 
-external_nd_C_unsafeInterleaveIO :: Curry_Prelude.C_IO a -> IDSupply -> Cover -> ConstStore -> a
+external_nd_C_unsafeInterleaveIO :: Curry_Prelude.C_IO a -> IDSupply -> Cover -> ConstStore -> Curry_Prelude.C_IO a
 external_nd_C_unsafeInterleaveIO io s cd cs = fromIO (unsafeInterleaveIO (toIO s cd cs io))

--- a/src/System/IO/Unsafe.kics2.hs
+++ b/src/System/IO/Unsafe.kics2.hs
@@ -1,4 +1,4 @@
-import System.IO.Unsafe (unsafePerformIO)
+import System.IO.Unsafe (unsafePerformIO, unsafeInterleaveIO)
 
 import KiCS2Debug (internalError)
 
@@ -8,3 +8,10 @@ external_d_C_unsafePerformIO io cd cs = unsafePerformIO (toIO errSupply cd cs io
 
 external_nd_C_unsafePerformIO :: Curry_Prelude.C_IO a -> IDSupply -> Cover -> ConstStore -> a
 external_nd_C_unsafePerformIO io s cd cs = unsafePerformIO (toIO s cd cs io)
+
+external_d_C_unsafeInterleaveIO :: Curry_Prelude.C_IO a -> Cover -> ConstStore -> a
+external_d_C_unsafeInterleaveIO io cd cs = fromIO (unsafeInterleaveIO (toIO errSupply cd cs io))
+  where errSupply = internalError "Unsafe.unsafeInterleaveIO: ID supply used"
+
+external_nd_C_unsafeInterleaveIO :: Curry_Prelude.C_IO a -> IDSupply -> Cover -> ConstStore -> a
+external_nd_C_unsafeInterleaveIO io s cd cs = fromIO (unsafeInterleaveIO (toIO s cd cs io))


### PR DESCRIPTION
As per the discussion in the frontend, this adds `unsafeInterleaveIO`, with both a native KiCS2 implementation and a fallback implementation for the other compilers.

As a quick example, the program

```curry
main = do
  x <- unsafeInterleaveIO (putStrLn "world")
  putStrLn "hello"
  case x of { () -> return () } -- Force evaluation
  case x of { () -> return () } -- Force evaluation again (does nothing)
```

should output

```
hello
world
```