### PR TITLE
Add `Data.Monoid` with a bunch of common monoids

### DIFF
--- a/src/Data/Monoid.curry
+++ b/src/Data/Monoid.curry
@@ -66,6 +66,17 @@ instance Monad Product where
 --- Maybe monoid returning the leftmost Just value.
 newtype First a = First { getFirst :: Maybe a }
 
+instance Functor First where
+  fmap f (First x) = First (f <$> x)
+
+instance Applicative First where
+  pure = First . pure
+  First f <*> First x = First (f <*> x)
+
+instance Monad First where
+  return = pure
+  First x >>= f = First (x >>= getFirst . f)
+
 instance Monoid (First a) where
   mempty = First Nothing
   mappend (First x) (First y) = First (x <|> y)
@@ -76,3 +87,14 @@ newtype Last a = Last { getLast :: Maybe a }
 instance Monoid (Last a) where
   mempty = Last Nothing
   mappend (Last x) (Last y) = Last (y <|> x)
+
+instance Functor Last where
+  fmap f (Last x) = Last (f <$> x)
+
+instance Applicative Last where
+  pure = Last . pure
+  Last f <*> Last x = Last (f <*> x)
+
+instance Monad Last where
+  return = pure
+  Last x >>= f = Last (x >>= getLast . f)

--- a/src/Data/Monoid.curry
+++ b/src/Data/Monoid.curry
@@ -1,0 +1,26 @@
+--- ----------------------------------------------------------------------------
+--- Library with some useful `Monoid` instances.
+---
+--- @version April 2025
+--- @category general
+--- ----------------------------------------------------------------------------
+
+module Data.Monoid
+  ( All (..), Any (..)
+  ) where
+
+--- Boolean monoid under (&&)
+newtype All = All { getAll :: Bool }
+  deriving (Eq, Ord, Show, Read)
+
+instance Monoid All where
+  mempty = All True
+  mappend (All x) (All y) = All (x && y)
+
+--- Boolean monoid under (||)
+newtype Any = Any { getAny :: Bool }
+  deriving (Eq, Ord, Show, Read)
+
+instance Monoid Any where
+  mempty = Any False
+  mappend (Any x) (Any y) = Any (x || y)

--- a/src/Data/Monoid.curry
+++ b/src/Data/Monoid.curry
@@ -6,7 +6,7 @@
 --- ----------------------------------------------------------------------------
 
 module Data.Monoid
-  ( All (..), Any (..)
+  ( All (..), Any (..), Sum (..), Product (..)
   ) where
 
 --- Boolean monoid under (&&)
@@ -24,3 +24,19 @@ newtype Any = Any { getAny :: Bool }
 instance Monoid Any where
   mempty = Any False
   mappend (Any x) (Any y) = Any (x || y)
+
+--- Monoid under addition.
+newtype Sum a = Sum { getSum :: a }
+  deriving (Eq, Ord, Show, Read)
+
+instance Num a => Monoid (Sum a) where
+  mempty = Sum 0
+  mappend (Sum x) (Sum y) = Sum (x + y)
+
+--- Monoid under multiplication.
+newtype Product a = Product { getProduct :: a }
+  deriving (Eq, Ord, Show, Read)
+
+instance Num a => Monoid (Product a) where
+  mempty = Product 1
+  mappend (Product x) (Product y) = Product (x * y)

--- a/src/Data/Monoid.curry
+++ b/src/Data/Monoid.curry
@@ -65,6 +65,7 @@ instance Monad Product where
 
 --- Maybe monoid returning the leftmost Just value.
 newtype First a = First { getFirst :: Maybe a }
+  deriving (Eq, Ord, Show, Read)
 
 instance Functor First where
   fmap f (First x) = First (f <$> x)
@@ -83,6 +84,7 @@ instance Monoid (First a) where
 
 --- Maybe monoid returning the rightmost Just value.
 newtype Last a = Last { getLast :: Maybe a }
+  deriving (Eq, Ord, Show, Read)
 
 instance Monoid (Last a) where
   mempty = Last Nothing

--- a/src/Data/Monoid.curry
+++ b/src/Data/Monoid.curry
@@ -6,7 +6,7 @@
 --- ----------------------------------------------------------------------------
 
 module Data.Monoid
-  ( All (..), Any (..), Sum (..), Product (..)
+  ( All (..), Any (..), Sum (..), Product (..), First (..), Last (..)
   ) where
 
 --- Boolean monoid under (&&)
@@ -62,3 +62,17 @@ instance Applicative Product where
 instance Monad Product where
   return = Product
   Product x >>= f = f x
+
+--- Maybe monoid returning the leftmost Just value.
+newtype First a = First { getFirst :: Maybe a }
+
+instance Monoid (First a) where
+  mempty = First Nothing
+  mappend (First x) (First y) = First (x <|> y)
+
+--- Maybe monoid returning the rightmost Just value.
+newtype Last a = Last { getLast :: Maybe a }
+
+instance Monoid (Last a) where
+  mempty = Last Nothing
+  mappend (Last x) (Last y) = Last (y <|> x)

--- a/src/Data/Monoid.curry
+++ b/src/Data/Monoid.curry
@@ -33,6 +33,17 @@ instance Num a => Monoid (Sum a) where
   mempty = Sum 0
   mappend (Sum x) (Sum y) = Sum (x + y)
 
+instance Functor Sum where
+  fmap f (Sum x) = Sum (f x)
+
+instance Applicative Sum where
+  pure = Sum
+  Sum f <*> Sum x = Sum (f x)
+
+instance Monad Sum where
+  return = Sum
+  Sum x >>= f = f x
+
 --- Monoid under multiplication.
 newtype Product a = Product { getProduct :: a }
   deriving (Eq, Ord, Show, Read)
@@ -40,3 +51,14 @@ newtype Product a = Product { getProduct :: a }
 instance Num a => Monoid (Product a) where
   mempty = Product 1
   mappend (Product x) (Product y) = Product (x * y)
+
+instance Functor Product where
+  fmap f (Product x) = Product (f x)
+
+instance Applicative Product where
+  pure = Product
+  Product f <*> Product x = Product (f x)
+
+instance Monad Product where
+  return = Product
+  Product x >>= f = f x


### PR DESCRIPTION
This ports over a number of monoids from Haskell's `Data.Monoid`, including:

- `All` and `Any` on booleans
- `Sum` and `Product` on `Num` types
- `First` and `Last` on `Maybe` types